### PR TITLE
Fix teleport blocking checks and /player commands output and tab-completion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea
 target
-.vscode/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+.vscode/*

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.co.shadowtrilogy</groupId>
     <artifactId>Hardcore24</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>2.0.1</version>
     <packaging>jar</packaging>
 
     <name>Hardcore24</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.co.shadowtrilogy</groupId>
     <artifactId>Hardcore24</artifactId>
-    <version>2.0.1</version>
+    <version>2.1</version>
     <packaging>jar</packaging>
 
     <name>Hardcore24</name>

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManager.java
@@ -11,6 +11,7 @@ import uk.co.shadowtrilogy.hardcore24.Hardcore24;
 import uk.co.shadowtrilogy.hardcore24.PlayerDeathData;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.UUID;
 
 public class playerManager implements CommandExecutor {
@@ -37,8 +38,8 @@ public class playerManager implements CommandExecutor {
         if(args.length>0){
 
             if(args[OPERATION].toUpperCase().contains(REMOVE)){
-                if(args.length<3){
-                    commandSender.sendMessage(ChatColor.RED + "Argument error! More arguments are needed");
+                if(args.length != 2){
+                    commandSender.sendMessage(ChatColor.RED + "Argument error! Please use: /player unban <player>");
                     return true;
                 }
 
@@ -53,21 +54,20 @@ public class playerManager implements CommandExecutor {
                 }*/
 
 
-                try{
-                    UUID player = (getPlayer(args[PLAYER]));
-                    if(player==null){
-                        throw new NullPointerException();
-                    }
-                    if(Hardcore24.deadPlayers.containsKey(player)){
-                        Hardcore24.deadPlayers.remove(player);
-                        commandSender.sendMessage(ChatColor.BLUE + "Successfully unbanned player \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] +  ChatColor.BLUE + "\"  from hardcore...");
-
-
-                    }
-                } catch (NullPointerException ex){
-                    commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" was never banned from hardcore...");
-
+                UUID player = getPlayer(args[PLAYER]);
+                if(player==null){
+                    commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" not found...");
+                    return true;
                 }
+
+                PlayerDeathData activeBan = Hardcore24.deadPlayers.get(player);
+                if(activeBan == null){
+                    commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" is not banned from hardcore...");
+                    return true;
+                }
+
+                Hardcore24.deadPlayers.remove(player);
+                commandSender.sendMessage(ChatColor.BLUE + "Successfully unbanned player \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] + ChatColor.BLUE + "\" from all hardcore bans.");
 
 
                return true;
@@ -75,7 +75,7 @@ public class playerManager implements CommandExecutor {
             }
             if(args[OPERATION].toUpperCase().contains(ADD)){
                 if(args.length<3){
-                    commandSender.sendMessage(ChatColor.RED + "Argument error! More arguments are needed");
+                    commandSender.sendMessage(ChatColor.RED + "Argument error! Please use: /player ban <player> <world>");
                     return true;
                 }
 
@@ -84,8 +84,8 @@ public class playerManager implements CommandExecutor {
                     return true;
                 }
 
-                if(!worldExists(args[WORLD])){
-                    commandSender.sendMessage(ChatColor.RED + "Error! World \"" + args[WORLD] + "\" not found...");
+                if(!worldIsInConfiguredGroup(args[WORLD])){
+                    commandSender.sendMessage(ChatColor.RED + "Error! World \"" + args[WORLD] + "\" is not configured in any hardcore group...");
                     return true;
                 }
 
@@ -111,8 +111,66 @@ public class playerManager implements CommandExecutor {
 
             }
             if(args[OPERATION].toUpperCase().contains(LIST)){
-                System.out.println(Hardcore24.deadPlayers);
-                //TODO fix
+                if(args.length==1){
+                    if(Hardcore24.deadPlayers.isEmpty()){
+                        commandSender.sendMessage(ChatColor.GREEN + "There are no players currently banned from hardcore.");
+                        return true;
+                    }
+
+                    commandSender.sendMessage(ChatColor.BLUE + "Hardcore banned players (" + Hardcore24.deadPlayers.size() + "):");
+                    for(Map.Entry<UUID, PlayerDeathData> entry : Hardcore24.deadPlayers.entrySet()){
+                        String listedName = Hardcore24.plugin.getServer().getOfflinePlayer(entry.getKey()).getName();
+                        if(listedName == null){
+                            listedName = entry.getKey().toString();
+                        }
+
+                        PlayerDeathData data = entry.getValue();
+                        LocalDateTime unbanTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+                        String groupName = Hardcore24.worlds.get(data.world);
+                        if(groupName==null){
+                            groupName = "(unmapped for world \"" + data.world + "\")";
+                        }
+
+                        commandSender.sendMessage(ChatColor.BLUE + "- " + ChatColor.LIGHT_PURPLE + listedName + ChatColor.BLUE + " | Group: " + ChatColor.GREEN + groupName + ChatColor.BLUE + " | Unban: " + ChatColor.GREEN + unbanTime);
+                    }
+                    return true;
+                }
+
+                if(args.length>2){
+                    commandSender.sendMessage(ChatColor.RED + "Argument error! Please use: /player list or /player list <player>");
+                    return true;
+                }
+
+                if(!playerExists(args[PLAYER])){
+                    commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" not found...");
+                    return true;
+                }
+
+                UUID player = getPlayer(args[PLAYER]);
+                if(player==null){
+                    commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" not found...");
+                    return true;
+                }
+
+                if(!Hardcore24.deadPlayers.containsKey(player)){
+                    commandSender.sendMessage(ChatColor.GREEN + "Player \"" + args[PLAYER] + "\" is not currently banned from hardcore.");
+                    return true;
+                }
+
+                PlayerDeathData data = Hardcore24.deadPlayers.get(player);
+                LocalDateTime unbanTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+                String groupName = Hardcore24.worlds.get(data.world);
+                boolean banElapsed = LocalDateTime.now().isAfter(unbanTime);
+
+                if(groupName==null){
+                    groupName = "(unmapped for world \"" + data.world + "\")";
+                }
+
+                commandSender.sendMessage(ChatColor.BLUE + "Hardcore status for \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] + ChatColor.BLUE + "\": " + ChatColor.RED + "BANNED");
+                commandSender.sendMessage(ChatColor.BLUE + "Group: " + ChatColor.GREEN + groupName + ChatColor.BLUE + " | Death world: " + ChatColor.GREEN + data.world);
+                commandSender.sendMessage(ChatColor.BLUE + "Unban time: " + ChatColor.GREEN + unbanTime + ChatColor.BLUE + " | Ban elapsed: " + ChatColor.GREEN + banElapsed);
+
+                return true;
 
             }
 
@@ -166,5 +224,12 @@ public class playerManager implements CommandExecutor {
     }
         return false;
 
+    }
+
+    boolean worldIsInConfiguredGroup(String worldName){
+        if(!worldExists(worldName)){
+            return false;
+        }
+        return Hardcore24.worlds.containsKey(worldName);
     }
 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManagerTabComplete.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManagerTabComplete.java
@@ -1,13 +1,12 @@
 package uk.co.shadowtrilogy.hardcore24.commands.players;
 
-import org.bukkit.World;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import uk.co.shadowtrilogy.hardcore24.Hardcore24;
-import uk.co.shadowtrilogy.hardcore24.json.groups.groupdata;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,9 +25,6 @@ public class playerManagerTabComplete implements TabCompleter {
                             list.add("unban");
                             list.add("list");
 
-
-
-
                             return list;
 
                         }
@@ -36,10 +32,15 @@ public class playerManagerTabComplete implements TabCompleter {
                     }
 
                     case 2: {
-                        //List<String> list = new ArrayList<>();
-                        if (commandSender.isOp() || commandSender.hasPermission("hardcore.manage.groups")) {
+                        List<String> list = new ArrayList<>();
+                        if (commandSender.isOp() || commandSender.hasPermission("hardcore.manage.players")) {
+                            for (OfflinePlayer player : Hardcore24.plugin.getServer().getOfflinePlayers()) {
+                                if (player.getName() != null) {
+                                    list.add(player.getName());
+                                }
+                            }
 
-                          return null;
+                            return list;
 
 
                         }
@@ -51,9 +52,9 @@ public class playerManagerTabComplete implements TabCompleter {
                         List<String> list = new ArrayList<>();
                         if (commandSender.isOp() || commandSender.hasPermission("hardcore.manage.players")) {
 
-                            if(args[0].toUpperCase().contains("ban")) {
-                                for (World w : Hardcore24.plugin.getServer().getWorlds()) {
-                                    list.add(w.getName());
+                            if (args[0].equalsIgnoreCase("ban")) {
+                                for (String worldName : Hardcore24.worlds.keySet()) {
+                                    list.add(worldName);
                                 }
                             }
 
@@ -66,12 +67,15 @@ public class playerManagerTabComplete implements TabCompleter {
 
 
                     }
+
+                    default:
+                        return new ArrayList<>();
                 }
 
             }
         }
 
 
-        return null;
+        return new ArrayList<>();
     }
 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerTransportManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerTransportManager.java
@@ -22,27 +22,34 @@ public class PlayerTransportManager implements Listener {
 
 
                 PlayerDeathData data = Hardcore24.deadPlayers.get(ev.getPlayer().getUniqueId());
+                String playerName = ev.getPlayer().getName();
 
                 LocalDateTime deathTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
 
                 String group = Hardcore24.worlds.get(data.world);
 
-                System.out.println(deathTime.isAfter(LocalDateTime.now()));
-                System.out.println(deathTime.isBefore(LocalDateTime.now()));
+                LocalDateTime now = LocalDateTime.now();
+                boolean banElapsed = now.isAfter(deathTime);
+                Hardcore24.plugin.getLogger().info("Teleport ban-time check for " + playerName + ": expires=" + deathTime + ", now=" + now + ", elapsed=" + banElapsed);
 
 
-                if(LocalDateTime.now().isAfter(deathTime)){
+                if(banElapsed){
 
                     Hardcore24.deadPlayers.remove(ev.getPlayer().getUniqueId());
                     ev.getPlayer().sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "Congratulations, you have been unbanned from hardcore... Good luck");
 
 
                 } else {
-                    if(doesGroupContainWorld(group, data.world)) {
-                        ev.setCancelled(true);
+                    String destinationWorld = ev.getTo() != null && ev.getTo().getWorld() != null
+                    ? ev.getTo().getWorld().getName() : null;
 
-                        ev.getPlayer().sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "You died in hardcore... You will be unbanned at " + deathTime.toString());
+                    boolean destinationInBannedGroup = destinationWorld != null && doesGroupContainWorld(group, destinationWorld);
+                    Hardcore24.plugin.getLogger().info("Teleport destination group check for " + playerName + ": destination=" + destinationWorld + ", bannedGroup=" + group + ", inBannedGroup=" + destinationInBannedGroup);
 
+                    if (destinationInBannedGroup) {
+                       ev.setCancelled(true);
+                        ev.getPlayer().sendMessage(ChatColor.RED + "" + ChatColor.ITALIC
+                            + "You died in hardcore... You will be unbanned at " + deathTime);
                     }
 
                 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ version: '${project.version}'
 main: uk.co.shadowtrilogy.hardcore24.Hardcore24
 api-version: '1.21'
 load: STARTUP
-authors: [BlueNightFury46]
+authors: [BlueNightFury46, deathbypain]
 description: a 24 hour (default) hardcore death timeout plugin!
 website: bluenightfury46.dev
 commands:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: Hardcore24
-version: '2.0'
+version: '${project.version}'
 main: uk.co.shadowtrilogy.hardcore24.Hardcore24
 api-version: '1.21'
 load: STARTUP


### PR DESCRIPTION
Upstream behavior seemed to be blocking *all* teleports between worlds when a player was banned from any world. As in, if Player_A was banned from group hardcore_group, it was blocking teleports between worlds that were not a part of that group at all. 

I changed the teleport-intercept check to only check against the *destination* world, and cancel the teleport only if that destination world is part of the banned world group.

Also, /player list wasn't implemented completely with a "TODO//fix" comment, so I went ahead and setup output for "/player list" and "/player list PLAYER_NAME" so either form will output some useful info to the game chat. 

Reworked /player ban and unban command logic and chat output, and made adjustments to the tab-completion functionality for all of the /player commands.

Changed some existing server STDOUT output to use plugin.getlogger instead, and made the messages a little more informative when blocking a teleport.

I've tested these changes pretty comprehensively on two different servers, both running paper 26.2. One was a dev server with a very minimal plugin list, and the other my production server with a lot more active plugins.

AI disclosure: I was assisted by github copilot, but every change made by the assistant was made at my specific request, and I personally reviewed every line of code.