### PR TITLE
Feature: ban ejections and offline notification queue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 target
+.vscode/

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>uk.co.shadowtrilogy</groupId>
     <artifactId>Hardcore24</artifactId>
-    <version>2.1</version>
+    <version>2.2</version>
     <packaging>jar</packaging>
 
     <name>Hardcore24</name>

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/GroupWorldUtils.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/GroupWorldUtils.java
@@ -10,6 +10,8 @@ import uk.co.shadowtrilogy.hardcore24.json.groups.json_location;
 public class GroupWorldUtils {
 
     // Checks if a group contains a specified world.
+    // TODO: PlayerDeathManager.respawn could probably use this method as well?
+
     public static boolean groupContainsWorld(String groupName, String worldName){
         for(groupdata group : Hardcore24.groups){
             if(group.group_name != null && group.group_name.equalsIgnoreCase(groupName) && group.worlds != null){
@@ -23,9 +25,8 @@ public class GroupWorldUtils {
         return false;
     }
 
-    /* Returns the respawn location for a specific group with inbuilt null checks.
-       TODO: PlayerDeathManager.respawn could probably use this method as well? */
-
+    // Returns the respawn location for a specific group with inbuilt null checks.
+    
     public static Location getGroupRespawnLocation(String groupName){
         for(groupdata group : Hardcore24.groups){
             if(group.group_name != null && group.group_name.equalsIgnoreCase(groupName)){

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/GroupWorldUtils.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/GroupWorldUtils.java
@@ -1,0 +1,47 @@
+package uk.co.shadowtrilogy.hardcore24;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import uk.co.shadowtrilogy.hardcore24.json.groups.groupdata;
+import uk.co.shadowtrilogy.hardcore24.json.groups.json_location;
+
+/*  Utility class for handling group-related world operations. */
+
+public class GroupWorldUtils {
+
+    // Checks if a group contains a specified world.
+    public static boolean groupContainsWorld(String groupName, String worldName){
+        for(groupdata group : Hardcore24.groups){
+            if(group.group_name != null && group.group_name.equalsIgnoreCase(groupName) && group.worlds != null){
+                for(String world : group.worlds){
+                    if(world != null && world.equalsIgnoreCase(worldName)){
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /* Returns the respawn location for a specific group with inbuilt null checks.
+       TODO: PlayerDeathManager.respawn could probably use this method as well? */
+
+    public static Location getGroupRespawnLocation(String groupName){
+        for(groupdata group : Hardcore24.groups){
+            if(group.group_name != null && group.group_name.equalsIgnoreCase(groupName)){
+                json_location respawn = group.respawn_location;
+                if(respawn == null || !respawn.hasBeenSet){
+                    return null;
+                }
+
+                World world = Hardcore24.plugin.getServer().getWorld(respawn.world);
+                if(world == null){
+                    return null;
+                }
+
+                return new Location(world, respawn.x, respawn.y, respawn.z);
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/Hardcore24.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/Hardcore24.java
@@ -22,6 +22,7 @@ import uk.co.shadowtrilogy.hardcore24.json.world_group.worldgroupdataContainer;
 
 
 import java.io.File;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
@@ -31,6 +32,7 @@ public final class Hardcore24 extends JavaPlugin {
 
     @NotNull public static HashMap<UUID, PlayerDeathData> deadPlayers = new HashMap<>();
     @NotNull public static HashMap<UUID, String> pendingPlayerNotifications = new HashMap<>();
+    @NotNull public static HashMap<UUID, LocalDateTime> activeEjectionDeadlines = new HashMap<>();
 
     @NotNull public static HashMap<String, String> worlds = new HashMap<>();
     @NotNull public static Set<groupdata> groups = new HashSet<groupdata>();
@@ -69,7 +71,7 @@ public final class Hardcore24 extends JavaPlugin {
 
 
         getServer().getPluginManager().registerEvents(new PlayerDeathManager(), this);
-    getServer().getPluginManager().registerEvents(new PlayerNotificationManager(), this);
+        getServer().getPluginManager().registerEvents(new PlayerNotificationManager(), this);
         getServer().getPluginManager().registerEvents(new PlayerTransportManager(), this);
 
 
@@ -115,7 +117,7 @@ public final class Hardcore24 extends JavaPlugin {
 
 
         final String deadPlayers_filename = "players.json";
-    final String pendingNotifications_filename = "pending_notifications.json";
+        final String pendingNotifications_filename = "pending_notifications.json";
         final String worlds_filename = "worlds.json";
         final String groups_filename = "groups.json";
 
@@ -145,7 +147,7 @@ public final class Hardcore24 extends JavaPlugin {
 
         deadPlayers = Player_dataJSON.jsonInit(death_data, deadPlayers).players;
 
-    pendingPlayerNotifications = Player_notificationJSON.jsonInit(notification_data, pendingPlayerNotifications).notifications;
+        pendingPlayerNotifications = Player_notificationJSON.jsonInit(notification_data, pendingPlayerNotifications).notifications;
 
         worlds = World_groupJSON.jsonInit(world_data, worlds).world_groups;
 

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/Hardcore24.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/Hardcore24.java
@@ -8,10 +8,13 @@ import uk.co.shadowtrilogy.hardcore24.commands.reload.reload;
 import uk.co.shadowtrilogy.hardcore24.commands.worlds.worldGroups;
 import uk.co.shadowtrilogy.hardcore24.commands.worlds.worldGroupsTabCompleter;
 import uk.co.shadowtrilogy.hardcore24.events.PlayerDeathManager;
+import uk.co.shadowtrilogy.hardcore24.events.PlayerNotificationManager;
 import uk.co.shadowtrilogy.hardcore24.events.PlayerTransportManager;
 import uk.co.shadowtrilogy.hardcore24.json.groups.Group_dataJSON;
 import uk.co.shadowtrilogy.hardcore24.json.groups.groupdata;
 import uk.co.shadowtrilogy.hardcore24.json.groups.groupdataContainer;
+import uk.co.shadowtrilogy.hardcore24.json.notifications.Player_notificationJSON;
+import uk.co.shadowtrilogy.hardcore24.json.notifications.playernotificationContainer;
 import uk.co.shadowtrilogy.hardcore24.json.player_data.Player_dataJSON;
 import uk.co.shadowtrilogy.hardcore24.json.player_data.playerdataContainer;
 import uk.co.shadowtrilogy.hardcore24.json.world_group.World_groupJSON;
@@ -27,12 +30,14 @@ import java.util.UUID;
 public final class Hardcore24 extends JavaPlugin {
 
     @NotNull public static HashMap<UUID, PlayerDeathData> deadPlayers = new HashMap<>();
+    @NotNull public static HashMap<UUID, String> pendingPlayerNotifications = new HashMap<>();
 
     @NotNull public static HashMap<String, String> worlds = new HashMap<>();
     @NotNull public static Set<groupdata> groups = new HashSet<groupdata>();
 
 
     final String deadPlayers_filename = "players.json";
+    final String pendingNotifications_filename = "pending_notifications.json";
     final String worlds_filename = "worlds.json";
     final String groups_filename = "groups.json";
 
@@ -64,6 +69,7 @@ public final class Hardcore24 extends JavaPlugin {
 
 
         getServer().getPluginManager().registerEvents(new PlayerDeathManager(), this);
+    getServer().getPluginManager().registerEvents(new PlayerNotificationManager(), this);
         getServer().getPluginManager().registerEvents(new PlayerTransportManager(), this);
 
 
@@ -88,6 +94,9 @@ public final class Hardcore24 extends JavaPlugin {
         File death_data  = new File(getDataFolder(), deadPlayers_filename);
        deadPlayers = Player_dataJSON.jsonInit(death_data, deadPlayers).players;
 
+        File notification_data = new File(getDataFolder(), pendingNotifications_filename);
+        pendingPlayerNotifications = Player_notificationJSON.jsonInit(notification_data, pendingPlayerNotifications).notifications;
+
         File world_data  = new File(getDataFolder(), worlds_filename);
         worlds = World_groupJSON.jsonInit(world_data, worlds).world_groups;
 
@@ -106,6 +115,7 @@ public final class Hardcore24 extends JavaPlugin {
 
 
         final String deadPlayers_filename = "players.json";
+    final String pendingNotifications_filename = "pending_notifications.json";
         final String worlds_filename = "worlds.json";
         final String groups_filename = "groups.json";
 
@@ -113,6 +123,10 @@ public final class Hardcore24 extends JavaPlugin {
         File death_data  = new File(Hardcore24.plugin.getDataFolder(), deadPlayers_filename);
         playerdataContainer players_container = new playerdataContainer(deadPlayers);
         Player_dataJSON.jsonSave(players_container, death_data);
+
+        File notification_data = new File(Hardcore24.plugin.getDataFolder(), pendingNotifications_filename);
+        playernotificationContainer notifications_container = new playernotificationContainer(pendingPlayerNotifications);
+        Player_notificationJSON.jsonSave(notifications_container, notification_data);
 
         //worlds.json shutdown logic
         File world_data  = new File(Hardcore24.plugin.getDataFolder(), worlds_filename);
@@ -130,6 +144,8 @@ public final class Hardcore24 extends JavaPlugin {
         Hardcore24.plugin.reloadConfig();
 
         deadPlayers = Player_dataJSON.jsonInit(death_data, deadPlayers).players;
+
+    pendingPlayerNotifications = Player_notificationJSON.jsonInit(notification_data, pendingPlayerNotifications).notifications;
 
         worlds = World_groupJSON.jsonInit(world_data, worlds).world_groups;
 
@@ -154,6 +170,11 @@ public final class Hardcore24 extends JavaPlugin {
         File death_data  = new File(getDataFolder(), deadPlayers_filename);
         playerdataContainer players_container = new playerdataContainer(deadPlayers);
         Player_dataJSON.jsonSave(players_container, death_data);
+
+        //pending_notifications.json shutdown logic
+        File notification_data = new File(getDataFolder(), pendingNotifications_filename);
+        playernotificationContainer notifications_container = new playernotificationContainer(pendingPlayerNotifications);
+        Player_notificationJSON.jsonSave(notifications_container, notification_data);
 
         //worlds.json shutdown logic
         File world_data  = new File(getDataFolder(), worlds_filename);

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/PlayerBanEjectionUtils.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/PlayerBanEjectionUtils.java
@@ -1,0 +1,119 @@
+package uk.co.shadowtrilogy.hardcore24;
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Utility class for handling player ejection related to hardcore bans.
+ * Provides methods to warn players, schedule ejections, and clear pending ejections.
+ */
+
+public class PlayerBanEjectionUtils {
+
+    // TODO: Consider making the ejection grace period adjustable via config.yaml
+    private static final long EJECTION_GRACE_SECONDS = 30L;
+
+    /*
+     * Warns the player and schedules their ejection from the current world if they are banned.
+     * Prevents player from loading into a banned world if they were admin-banned while offline.
+     */
+    public static void warnAndScheduleEjectionIfNeeded(Player player, PlayerDeathData banData){
+        if(player == null || banData == null){
+            return;
+        }
+
+        if(PlayerBanUtils.isBanElapsed(banData)){
+            Hardcore24.deadPlayers.remove(player.getUniqueId());
+            clearPendingEjection(player.getUniqueId());
+            return;
+        }
+
+        String bannedGroupName = Hardcore24.worlds.get(banData.world);
+        if(bannedGroupName == null){
+            clearPendingEjection(player.getUniqueId());
+            return;
+        }
+
+        String currentWorldName = player.getWorld() == null ? null : player.getWorld().getName();
+        if(currentWorldName == null || !GroupWorldUtils.groupContainsWorld(bannedGroupName, currentWorldName)){
+            clearPendingEjection(player.getUniqueId());
+            return;
+        }
+
+        UUID playerId = player.getUniqueId();
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime existingDeadline = Hardcore24.activeEjectionDeadlines.get(playerId);
+
+        if(existingDeadline == null){
+            LocalDateTime deadline = now.plusSeconds(EJECTION_GRACE_SECONDS);
+            Hardcore24.activeEjectionDeadlines.put(playerId, deadline);
+            player.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "You will be ejected from this world in " + formatRemainingSeconds(deadline, now) + "...");
+            scheduleEjection(playerId, EJECTION_GRACE_SECONDS);
+            return;
+        }
+
+        if(existingDeadline.isAfter(now)){
+            player.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "You will be ejected from this world in " + formatRemainingSeconds(existingDeadline, now) + "...");
+            return;
+        }
+
+        LocalDateTime immediateDeadline = now.plusSeconds(1L);
+        Hardcore24.activeEjectionDeadlines.put(playerId, immediateDeadline);
+        player.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "Your ejection grace period expired while you were offline. You will be ejected from this world now.");
+        scheduleEjection(playerId, 1L);
+    }
+
+    public static boolean clearPendingEjection(UUID playerId){
+        return Hardcore24.activeEjectionDeadlines.remove(playerId) != null;
+    }
+
+    private static void scheduleEjection(UUID playerId, long delaySeconds){
+        Hardcore24.plugin.getServer().getScheduler().runTaskLater(Hardcore24.plugin, () -> {
+            Player onlinePlayer = Hardcore24.plugin.getServer().getPlayer(playerId);
+            if(onlinePlayer == null || !onlinePlayer.isOnline()){
+                return;
+            }
+
+            PlayerDeathData activeBan = PlayerBanUtils.getActiveBan(playerId);
+            if(activeBan == null){
+                clearPendingEjection(playerId);
+                return;
+            }
+
+            String activeGroupName = Hardcore24.worlds.get(activeBan.world);
+            if(activeGroupName == null){
+                clearPendingEjection(playerId);
+                return;
+            }
+
+            String liveWorldName = onlinePlayer.getWorld() == null ? null : onlinePlayer.getWorld().getName();
+            if(liveWorldName == null || !GroupWorldUtils.groupContainsWorld(activeGroupName, liveWorldName)){
+                clearPendingEjection(playerId);
+                return;
+            }
+
+            Location ejectionLocation = GroupWorldUtils.getGroupRespawnLocation(activeGroupName);
+            if(ejectionLocation == null){
+                Hardcore24.plugin.getLogger().severe("Failed to eject player \"" + onlinePlayer.getName() + "\" because group respawn location is missing for group \"" + activeGroupName + "\".");
+                onlinePlayer.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "Ejection failed because this hardcore group's respawn world is invalid. Please contact an admin.");
+                clearPendingEjection(playerId);
+                return;
+            }
+
+            clearPendingEjection(playerId);
+            onlinePlayer.teleport(ejectionLocation);
+            onlinePlayer.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "You were ejected from a hardcore world due to an active ban.");
+        }, 20L * delaySeconds);
+    }
+
+    private static String formatRemainingSeconds(LocalDateTime deadline, LocalDateTime now){
+        long remainingMillis = Math.max(0L, Duration.between(now, deadline).toMillis());
+        long remainingSeconds = Math.max(1L, (remainingMillis + 999L) / 1000L);
+        return remainingSeconds + (remainingSeconds == 1L ? " second" : " seconds");
+    }
+}

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/PlayerBanUtils.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/PlayerBanUtils.java
@@ -1,0 +1,40 @@
+package uk.co.shadowtrilogy.hardcore24;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Utility class for handling player bans related to hardcore deaths.
+ * Provides methods to check if a ban has elapsed and to retrieve active bans.
+ */
+
+public class PlayerBanUtils {
+
+    public static LocalDateTime getUnbanTime(PlayerDeathData data){
+        if(data == null){
+            return null;
+        }
+
+        return LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+    }
+
+    public static boolean isBanElapsed(PlayerDeathData data){
+        LocalDateTime unbanTime = getUnbanTime(data);
+        return unbanTime != null && LocalDateTime.now().isAfter(unbanTime);
+    }
+
+    // Retrieves the active ban for a player, if it exists and has not elapsed. Returns null otherwise.
+    public static PlayerDeathData getActiveBan(UUID playerId){
+        PlayerDeathData data = Hardcore24.deadPlayers.get(playerId);
+        if(data == null){
+            return null;
+        }
+
+        if(isBanElapsed(data)){
+            Hardcore24.deadPlayers.remove(playerId);
+            return null;
+        }
+
+        return data;
+    }
+}

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManager.java
@@ -2,6 +2,7 @@ package uk.co.shadowtrilogy.hardcore24.commands.players;
 
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
 import org.bukkit.World;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -69,6 +70,7 @@ public class playerManager implements CommandExecutor {
 
                 Hardcore24.deadPlayers.remove(player);
                 commandSender.sendMessage(ChatColor.BLUE + "Successfully unbanned player \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] + ChatColor.BLUE + "\" from all hardcore bans.");
+                notifyOrQueuePlayer(player, ChatColor.GREEN + "You have been unbanned from hardcore by a server admin.");
 
 
                return true;
@@ -97,8 +99,11 @@ public class playerManager implements CommandExecutor {
                     if(player==null){
                         throw new NullPointerException();
                     }
-                        Hardcore24.deadPlayers.put(player, new PlayerDeathData(args[WORLD], LocalDateTime.now()));
+                    Hardcore24.deadPlayers.put(player, new PlayerDeathData(args[WORLD], LocalDateTime.now()));
+                    PlayerDeathData newBanData = Hardcore24.deadPlayers.get(player);
+                    LocalDateTime unbanTime = LocalDateTime.of(newBanData.deathYear, newBanData.deathMonth, newBanData.deathDayOfMonth, newBanData.deathHour, newBanData.deathMinute, newBanData.deathSecond);
                     commandSender.sendMessage(ChatColor.BLUE + "Successfully banned player \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] +  ChatColor.BLUE + "\"  from hardcore world \"" + ChatColor.GREEN + args[WORLD] + ChatColor.BLUE + "\"");
+                    notifyOrQueuePlayer(player, ChatColor.RED + "" + ChatColor.ITALIC + "You have been banned from hardcore in world \"" + args[WORLD] + "\" by a server admin. Unban time: " + unbanTime);
 
 
                 } catch (NullPointerException ex){
@@ -237,5 +242,17 @@ public class playerManager implements CommandExecutor {
             return false;
         }
         return Hardcore24.worlds.containsKey(worldName);
+    }
+
+    void notifyOrQueuePlayer(UUID playerId, String message){
+        Player target = Hardcore24.plugin.getServer().getPlayer(playerId);
+        if(target != null && target.isOnline()){
+            Hardcore24.pendingPlayerNotifications.remove(playerId);
+            target.sendMessage(message);
+            return;
+        }
+
+        // Coalesce offline notifications by UUID so only latest state is delivered.
+        Hardcore24.pendingPlayerNotifications.put(playerId, message);
     }
 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/commands/players/playerManager.java
@@ -9,8 +9,13 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
 import uk.co.shadowtrilogy.hardcore24.Hardcore24;
+import uk.co.shadowtrilogy.hardcore24.PlayerBanEjectionUtils;
+import uk.co.shadowtrilogy.hardcore24.PlayerBanUtils;
 import uk.co.shadowtrilogy.hardcore24.PlayerDeathData;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.UUID;
@@ -62,15 +67,21 @@ public class playerManager implements CommandExecutor {
                     return true;
                 }
 
-                PlayerDeathData activeBan = Hardcore24.deadPlayers.get(player);
+                PlayerDeathData activeBan = PlayerBanUtils.getActiveBan(player);
                 if(activeBan == null){
                     commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" is not banned from hardcore...");
                     return true;
                 }
 
+                boolean hadPendingEjection = PlayerBanEjectionUtils.clearPendingEjection(player);
                 Hardcore24.deadPlayers.remove(player);
                 commandSender.sendMessage(ChatColor.BLUE + "Successfully unbanned player \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] + ChatColor.BLUE + "\" from all hardcore bans.");
                 notifyOrQueuePlayer(player, ChatColor.GREEN + "You have been unbanned from hardcore by a server admin.");
+
+                Player onlineTarget = Hardcore24.plugin.getServer().getPlayer(player);
+                if(hadPendingEjection && onlineTarget != null && onlineTarget.isOnline()){
+                    onlineTarget.sendMessage(ChatColor.YELLOW + "" + ChatColor.ITALIC + "Your ejection countdown has been cancelled. Be safe...");
+                }
 
 
                return true;
@@ -105,6 +116,11 @@ public class playerManager implements CommandExecutor {
                     commandSender.sendMessage(ChatColor.BLUE + "Successfully banned player \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] +  ChatColor.BLUE + "\"  from hardcore world \"" + ChatColor.GREEN + args[WORLD] + ChatColor.BLUE + "\"");
                     notifyOrQueuePlayer(player, ChatColor.RED + "" + ChatColor.ITALIC + "You have been banned from hardcore in world \"" + args[WORLD] + "\" by a server admin. Unban time: " + unbanTime);
 
+                    Player onlineTarget = Hardcore24.plugin.getServer().getPlayer(player);
+                    if(onlineTarget != null && onlineTarget.isOnline()){
+                        PlayerBanEjectionUtils.warnAndScheduleEjectionIfNeeded(onlineTarget, newBanData);
+                    }
+
 
                 } catch (NullPointerException ex){
                     commandSender.sendMessage(ChatColor.RED + "Error! Player \"" + args[PLAYER] + "\" not found...");
@@ -123,26 +139,42 @@ public class playerManager implements CommandExecutor {
                         return true;
                     }
 
-                    commandSender.sendMessage(ChatColor.BLUE + "Hardcore banned players (" + Hardcore24.deadPlayers.size() + "):");
-                    for(Map.Entry<UUID, PlayerDeathData> entry : Hardcore24.deadPlayers.entrySet()){
+                    List<String> activeBanLines = new ArrayList<>();
+
+                    for(Map.Entry<UUID, PlayerDeathData> entry : new HashMap<>(Hardcore24.deadPlayers).entrySet()){
+                        PlayerDeathData data = PlayerBanUtils.getActiveBan(entry.getKey());
+                        if(data == null){
+                            PlayerBanEjectionUtils.clearPendingEjection(entry.getKey());
+                            continue;
+                        }
+
                         String listedName = Hardcore24.plugin.getServer().getOfflinePlayer(entry.getKey()).getName();
                         if(listedName == null){
                             listedName = entry.getKey().toString();
                         }
 
-                        PlayerDeathData data = entry.getValue();
-                        LocalDateTime unbanTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+                        LocalDateTime unbanTime = PlayerBanUtils.getUnbanTime(data);
                         String groupName = Hardcore24.worlds.get(data.world);
                         if(groupName==null){
                             groupName = "(unmapped for world \"" + data.world + "\")";
                         }
-                      String res = "";
-                      res+=ChatColor.BLUE + "- " + ChatColor.LIGHT_PURPLE + listedName + ChatColor.BLUE;
-                      res+=" | Group: " + ChatColor.GREEN + groupName + ChatColor.BLUE;
-                      res+= " | Unban: " + ChatColor.GREEN + unbanTime + ChatColor.BLUE;
-                      res+= " | Deathworld: " + ChatColor.GREEN + data.world + ChatColor.BLUE;
+                        String res = "";
+                        res+=ChatColor.BLUE + "- " + ChatColor.LIGHT_PURPLE + listedName + ChatColor.BLUE;
+                        res+=" | Group: " + ChatColor.GREEN + groupName + ChatColor.BLUE;
+                        res+= " | Unban: " + ChatColor.GREEN + unbanTime + ChatColor.BLUE;
+                        res+= " | Deathworld: " + ChatColor.GREEN + data.world + ChatColor.BLUE;
 
-                        commandSender.sendMessage(res);
+                        activeBanLines.add(res);
+                    }
+
+                    if(activeBanLines.isEmpty()){
+                        commandSender.sendMessage(ChatColor.GREEN + "There are no players currently banned from hardcore.");
+                        return true;
+                    }
+
+                    commandSender.sendMessage(ChatColor.BLUE + "Hardcore banned players (" + activeBanLines.size() + "):");
+                    for(String activeBanLine : activeBanLines){
+                        commandSender.sendMessage(activeBanLine);
                     }
                     return true;
                 }
@@ -168,10 +200,15 @@ public class playerManager implements CommandExecutor {
                     return true;
                 }
 
-                PlayerDeathData data = Hardcore24.deadPlayers.get(player);
-                LocalDateTime unbanTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+                PlayerDeathData data = PlayerBanUtils.getActiveBan(player);
+                if(data == null){
+                    PlayerBanEjectionUtils.clearPendingEjection(player);
+                    commandSender.sendMessage(ChatColor.GREEN + "Player \"" + args[PLAYER] + "\" is not currently banned from hardcore.");
+                    return true;
+                }
+
+                LocalDateTime unbanTime = PlayerBanUtils.getUnbanTime(data);
                 String groupName = Hardcore24.worlds.get(data.world);
-                boolean banElapsed = LocalDateTime.now().isAfter(unbanTime);
 
                 if(groupName==null){
                     groupName = "(unmapped for world \"" + data.world + "\")";
@@ -179,20 +216,14 @@ public class playerManager implements CommandExecutor {
 
                 commandSender.sendMessage(ChatColor.BLUE + "Hardcore status for \"" + ChatColor.LIGHT_PURPLE + args[PLAYER] + ChatColor.BLUE + "\": " + ChatColor.RED + "BANNED");
                 commandSender.sendMessage(ChatColor.BLUE + "Group: " + ChatColor.GREEN + groupName + ChatColor.BLUE + " | Death world: " + ChatColor.GREEN + data.world);
-                commandSender.sendMessage(ChatColor.BLUE + "Unban time: " + ChatColor.GREEN + unbanTime + ChatColor.BLUE + " | Ban elapsed: " + ChatColor.GREEN + banElapsed);
+                commandSender.sendMessage(ChatColor.BLUE + "Unban time: " + ChatColor.GREEN + unbanTime);
 
                 return true;
 
             }
 
-
-
         }
-
         return true;
-
-
-
 
     }
 
@@ -216,9 +247,7 @@ public class playerManager implements CommandExecutor {
                 return player.getUniqueId();
             }
         }
-
         return null;
-
     }
 
 
@@ -229,12 +258,8 @@ public class playerManager implements CommandExecutor {
             if(p.toLowerCase().equalsIgnoreCase((w.getName().toLowerCase()))){
                 return true;
             }
-
-
-
-    }
+        }
         return false;
-
     }
 
     boolean worldIsInConfiguredGroup(String worldName){
@@ -244,6 +269,7 @@ public class playerManager implements CommandExecutor {
         return Hardcore24.worlds.containsKey(worldName);
     }
 
+    // Sends a message to the player if they are online, or queues it for later delivery if they are offline.
     void notifyOrQueuePlayer(UUID playerId, String message){
         Player target = Hardcore24.plugin.getServer().getPlayer(playerId);
         if(target != null && target.isOnline()){

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerDeathManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerDeathManager.java
@@ -25,6 +25,13 @@ public class PlayerDeathManager implements Listener {
 
 
         if(!ev.getPlayer().hasPermission("hardcore.immortal")){
+            // If the death occurred in a world that is not tracked by Hardcore24,
+            // do not apply a ban and simply allow default death behavior to proceed
+            String deathWorldName = ev.getPlayer().getWorld().getName();
+            if(!Hardcore24.worlds.containsKey(deathWorldName)){
+                return;
+            }
+
             try {
                 if (!Hardcore24.deadPlayers.containsKey(ev.getPlayer().getUniqueId())) {
 

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerDeathManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerDeathManager.java
@@ -8,10 +8,10 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
+import uk.co.shadowtrilogy.hardcore24.GroupWorldUtils;
 import uk.co.shadowtrilogy.hardcore24.Hardcore24;
 import uk.co.shadowtrilogy.hardcore24.PlayerDeathData;
 import uk.co.shadowtrilogy.hardcore24.json.groups.groupdata;
-import uk.co.shadowtrilogy.hardcore24.json.groups.json_location;
 
 import java.time.LocalDateTime;
 
@@ -34,7 +34,6 @@ public class PlayerDeathManager implements Listener {
                     //teleport.teleportToRespawnPoint(ev.getPlayer().getWorld(), ev.getPlayer());
 
                     //TODO fix timezones probably
-                    Hardcore24.deadPlayers.put(ev.getPlayer().getUniqueId(), new PlayerDeathData(ev.getPlayer().getWorld(), LocalDateTime.now()));
                     sendDeathBanNotification(ev.getPlayer());
 
                     try {
@@ -62,7 +61,6 @@ public class PlayerDeathManager implements Listener {
                 //teleport.teleportToRespawnPoint(ev.getPlayer().getWorld(), ev.getPlayer());
 
                 //TODO fix timezones probably
-                Hardcore24.deadPlayers.put(ev.getPlayer().getUniqueId(), new PlayerDeathData(ev.getPlayer().getWorld(), LocalDateTime.now()));
                 sendDeathBanNotification(ev.getPlayer());
 
                 try {
@@ -106,7 +104,7 @@ public class PlayerDeathManager implements Listener {
 
                 for(groupdata g : Hardcore24.groups){
                     if(g.group_name.equalsIgnoreCase(group_name)){
-                        if(!g.respawn_location.hasBeenSet){
+                        if(g.respawn_location == null || !g.respawn_location.hasBeenSet){
                             if(player.isOp() && Hardcore24.WARNINGS){
                                 player.sendMessage(ChatColor.RED+"Warning! The respawn location for group \"" + g.group_name + "\" has not been set...");
                                 Hardcore24.plugin.getLogger().warning("Warning! The respawn location for group \"" + g.group_name + "\" has not been set...");
@@ -114,18 +112,18 @@ public class PlayerDeathManager implements Listener {
                             } else if(Hardcore24.WARNINGS) {
                                 Hardcore24.plugin.getLogger().warning("Warning! The respawn location for group \"" + g.group_name + "\" has not been set...");
                             }
-                        }
-
-                        json_location loc = g.respawn_location;
-
-                        try{
-                            World w = Hardcore24.plugin.getServer().getWorld(loc.world);
-                            ev.setRespawnLocation(new Location(w, loc.x, loc.y, loc.z));
-
-                        }catch(NullPointerException ex){
-                            Hardcore24.plugin.getLogger().severe("Warning! World for teleport does not exist (how have you managed that then?)");
                             return;
                         }
+
+                        Location respawnLocation = GroupWorldUtils.getGroupRespawnLocation(g.group_name);
+                        if(respawnLocation == null){
+                            Hardcore24.plugin.getLogger().severe("Warning! Respawn location for group \"" + g.group_name + "\" is invalid. Check groups.json and ensure respawn world exists.");
+                            player.sendMessage(ChatColor.RED + "Warning! Hardcore respawn configuration is invalid. Using server default respawn...");
+                            return;
+                        }
+
+                        ev.setRespawnLocation(respawnLocation);
+                        return;
 
                     }
                 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerDeathManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerDeathManager.java
@@ -35,6 +35,7 @@ public class PlayerDeathManager implements Listener {
 
                     //TODO fix timezones probably
                     Hardcore24.deadPlayers.put(ev.getPlayer().getUniqueId(), new PlayerDeathData(ev.getPlayer().getWorld(), LocalDateTime.now()));
+                    sendDeathBanNotification(ev.getPlayer());
 
                     try {
                         if (Hardcore24.DROP_ENDERCHEST && !ev.getKeepInventory()) {
@@ -62,6 +63,7 @@ public class PlayerDeathManager implements Listener {
 
                 //TODO fix timezones probably
                 Hardcore24.deadPlayers.put(ev.getPlayer().getUniqueId(), new PlayerDeathData(ev.getPlayer().getWorld(), LocalDateTime.now()));
+                sendDeathBanNotification(ev.getPlayer());
 
                 try {
                     if (Hardcore24.DROP_ENDERCHEST && !ev.getKeepInventory()) {
@@ -141,5 +143,16 @@ public class PlayerDeathManager implements Listener {
             }
         }
 
+    }
+
+    private void sendDeathBanNotification(Player player){
+        PlayerDeathData data = Hardcore24.deadPlayers.get(player.getUniqueId());
+        if(data == null){
+            return;
+        }
+
+        Hardcore24.pendingPlayerNotifications.remove(player.getUniqueId());
+        LocalDateTime unbanTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+        player.sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "You are now banned from hardcore. Unban time: " + unbanTime);
     }
 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerNotificationManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerNotificationManager.java
@@ -4,18 +4,42 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerJoinEvent;
 import uk.co.shadowtrilogy.hardcore24.Hardcore24;
+import uk.co.shadowtrilogy.hardcore24.PlayerBanUtils;
+import uk.co.shadowtrilogy.hardcore24.PlayerBanEjectionUtils;
+import uk.co.shadowtrilogy.hardcore24.PlayerDeathData;
 
 import java.util.UUID;
+
+/**
+ * Manages player notifications related to hardcore bans and ejections.
+ * Listens for player join events and delivers any pending messages or handles ban status.
+ */
 
 public class PlayerNotificationManager implements Listener {
 
     @EventHandler
     public void onJoin(PlayerJoinEvent ev){
         UUID playerId = ev.getPlayer().getUniqueId();
-        String pendingMessage = Hardcore24.pendingPlayerNotifications.remove(playerId);
+        PlayerDeathData rawBan = Hardcore24.deadPlayers.get(playerId);
 
+        // Check if the player had a recent ban that has now expired. If so, notify them of their unban.
+        if(rawBan != null && PlayerBanUtils.getActiveBan(playerId) == null){
+            Hardcore24.pendingPlayerNotifications.remove(playerId);
+            PlayerBanEjectionUtils.clearPendingEjection(playerId);
+            ev.getPlayer().sendMessage("Congratulations, you have been unbanned from hardcore... Good luck");
+            return;
+        }
+
+        // Retrieve any pending notification message for the player.
+        String pendingMessage = Hardcore24.pendingPlayerNotifications.remove(playerId);
         if(pendingMessage != null && !pendingMessage.isEmpty()){
             ev.getPlayer().sendMessage(pendingMessage);
+        }
+
+        // If player is loading into a world where they are currently banned, handle their ejection.
+        PlayerDeathData activeBan = PlayerBanUtils.getActiveBan(playerId);
+        if(activeBan != null){
+            PlayerBanEjectionUtils.warnAndScheduleEjectionIfNeeded(ev.getPlayer(), activeBan);
         }
     }
 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerNotificationManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerNotificationManager.java
@@ -1,0 +1,21 @@
+package uk.co.shadowtrilogy.hardcore24.events;
+
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import uk.co.shadowtrilogy.hardcore24.Hardcore24;
+
+import java.util.UUID;
+
+public class PlayerNotificationManager implements Listener {
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent ev){
+        UUID playerId = ev.getPlayer().getUniqueId();
+        String pendingMessage = Hardcore24.pendingPlayerNotifications.remove(playerId);
+
+        if(pendingMessage != null && !pendingMessage.isEmpty()){
+            ev.getPlayer().sendMessage(pendingMessage);
+        }
+    }
+}

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerTransportManager.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/events/PlayerTransportManager.java
@@ -5,12 +5,18 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.player.PlayerTeleportEvent;
+import uk.co.shadowtrilogy.hardcore24.GroupWorldUtils;
 import uk.co.shadowtrilogy.hardcore24.Hardcore24;
+import uk.co.shadowtrilogy.hardcore24.PlayerBanEjectionUtils;
+import uk.co.shadowtrilogy.hardcore24.PlayerBanUtils;
 import uk.co.shadowtrilogy.hardcore24.PlayerDeathData;
-import uk.co.shadowtrilogy.hardcore24.json.groups.groupdata;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
+
+/**
+ * Listens for player teleport events and prevents players from entering worlds where they are currently banned.
+ * Notifies players when their ban has elapsed.
+ */
 
 public class PlayerTransportManager implements Listener {
 
@@ -21,29 +27,39 @@ public class PlayerTransportManager implements Listener {
             if(Hardcore24.deadPlayers.containsKey(ev.getPlayer().getUniqueId())){
 
 
-                PlayerDeathData data = Hardcore24.deadPlayers.get(ev.getPlayer().getUniqueId());
+                PlayerDeathData data = PlayerBanUtils.getActiveBan(ev.getPlayer().getUniqueId());
+
+                // If there is no active ban, clear any pending ejection and notify the player of their unban.
+                if(data == null){
+                    PlayerBanEjectionUtils.clearPendingEjection(ev.getPlayer().getUniqueId());
+                    ev.getPlayer().sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "Congratulations, you have been unbanned from hardcore... Good luck");
+                    return;
+                }
+
                 String playerName = ev.getPlayer().getName();
 
-                LocalDateTime deathTime = LocalDateTime.of(data.deathYear, data.deathMonth, data.deathDayOfMonth, data.deathHour, data.deathMinute, data.deathSecond);
+                LocalDateTime deathTime = PlayerBanUtils.getUnbanTime(data);
 
                 String group = Hardcore24.worlds.get(data.world);
 
                 LocalDateTime now = LocalDateTime.now();
-                boolean banElapsed = now.isAfter(deathTime);
+                boolean banElapsed = PlayerBanUtils.isBanElapsed(data);
                 Hardcore24.plugin.getLogger().info("Teleport ban-time check for " + playerName + ": expires=" + deathTime + ", now=" + now + ", elapsed=" + banElapsed);
 
 
                 if(banElapsed){
-
+                    // Remove the player from the list of dead players as their ban has elapsed, and notify
                     Hardcore24.deadPlayers.remove(ev.getPlayer().getUniqueId());
                     ev.getPlayer().sendMessage(ChatColor.RED + "" + ChatColor.ITALIC + "Congratulations, you have been unbanned from hardcore... Good luck");
 
 
                 } else {
+                    // Check if the player is attempting to teleport to a world within the banned group.
+                    // If so, cancel the teleport and notify the player of their ban.
                     String destinationWorld = ev.getTo() != null && ev.getTo().getWorld() != null
                     ? ev.getTo().getWorld().getName() : null;
 
-                    boolean destinationInBannedGroup = destinationWorld != null && doesGroupContainWorld(group, destinationWorld);
+                    boolean destinationInBannedGroup = destinationWorld != null && GroupWorldUtils.groupContainsWorld(group, destinationWorld);
                     Hardcore24.plugin.getLogger().info("Teleport destination group check for " + playerName + ": destination=" + destinationWorld + ", bannedGroup=" + group + ", inBannedGroup=" + destinationInBannedGroup);
 
                     if (destinationInBannedGroup) {
@@ -54,8 +70,6 @@ public class PlayerTransportManager implements Listener {
 
                 }
 
-
-
             }
 
         }catch(NullPointerException ex){
@@ -65,21 +79,5 @@ public class PlayerTransportManager implements Listener {
 
 
 
-    }
-
-
-    boolean doesGroupContainWorld(String group, String world){
-        ArrayList<groupdata> groups = new ArrayList<>(Hardcore24.groups);
-        for(groupdata g : groups){
-            if(g.group_name.equalsIgnoreCase(group)){
-                ArrayList<String> worlds = new ArrayList<>(g.worlds);
-                for(String str : worlds){
-                    if(str.equalsIgnoreCase(world)){
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/json/notifications/Player_notificationJSON.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/json/notifications/Player_notificationJSON.java
@@ -1,0 +1,109 @@
+package uk.co.shadowtrilogy.hardcore24.json.notifications;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import uk.co.shadowtrilogy.hardcore24.Hardcore24;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.ReadOnlyFileSystemException;
+import java.util.HashMap;
+import java.util.Scanner;
+import java.util.UUID;
+
+public class Player_notificationJSON {
+    public static playernotificationContainer jsonInit(File JSON_FILE, HashMap<UUID, String> defaultMap) {
+
+
+        try {
+            if (JSON_FILE!=null){
+
+
+                if(!JSON_FILE.exists()){
+                    throw new FileNotFoundException();
+                }
+
+
+                Scanner scan = new Scanner(JSON_FILE);
+
+                String tempstr = "";
+                while(scan.hasNextLine()){
+                    tempstr+=scan.nextLine();
+                }
+
+                scan.close();
+
+                if(tempstr.isEmpty()){
+                    return new playernotificationContainer(defaultMap);
+
+                }
+
+
+                playernotificationContainer data = new Gson().fromJson(tempstr, playernotificationContainer.class);
+
+                return data;
+
+
+                //END OF IF STATEMENT BY THE WAY (Java is impossible to read)
+            }
+
+        }
+        catch(NullPointerException e){
+            Hardcore24.plugin.getLogger().severe("JsonFileNullError, plugin shutting down");
+            return new playernotificationContainer(defaultMap);
+        }
+
+
+
+        catch(ExceptionInInitializerError | FileNotFoundException e){
+            return new playernotificationContainer(defaultMap);
+
+        }
+
+
+        return new playernotificationContainer(defaultMap);
+    }
+
+    public static void jsonSave(playernotificationContainer toJson, File JSON_FILE){
+
+        try {
+            if (JSON_FILE!=null){
+
+                if(!JSON_FILE.exists()){
+                    JSON_FILE.createNewFile();
+                }
+
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+
+                String str_data = gson.toJson(toJson);
+
+                FileWriter writer = new FileWriter(JSON_FILE);
+
+                writer.write(str_data);
+
+                writer.close();
+
+
+                //END OF IF STATEMENT BY THE WAY (Java is impossible to read)
+            }
+
+        }
+        catch(NullPointerException e){
+            Hardcore24.plugin.getLogger().severe("JsonFileNullError, plugin shutting down");
+        }
+
+        catch(ReadOnlyFileSystemException e){
+            Hardcore24.plugin.getLogger().severe("Json file is read only... Shutting down (How did you do that then?)");
+        }
+
+        catch (FileNotFoundException e) {
+            JSON_FILE.mkdirs();
+
+        } catch (IOException e) {
+            Hardcore24.plugin.getLogger().severe("Failed to create JSON file...");
+        }
+    }
+}

--- a/src/main/java/uk/co/shadowtrilogy/hardcore24/json/notifications/playernotificationContainer.java
+++ b/src/main/java/uk/co/shadowtrilogy/hardcore24/json/notifications/playernotificationContainer.java
@@ -1,0 +1,12 @@
+package uk.co.shadowtrilogy.hardcore24.json.notifications;
+
+import java.util.HashMap;
+import java.util.UUID;
+
+public class playernotificationContainer {
+    public HashMap<UUID, String> notifications;
+
+    public playernotificationContainer(HashMap<UUID, String> notificationMap){
+        notifications = notificationMap;
+    }
+}


### PR DESCRIPTION
## Summary

This PR expands ban feedback and adds ban **enforcement** across online, offline, login, teleport, and respawn flows.

Also fixes several edge cases discovered during in-game testing and bumps the plugin version to `2.2`.

## What changed

### Ban and unban notifications

- Notify online players immediately when they are banned or unbanned by an admin.
- Queue notifications for offline players
- Persist queued notifications across restarts.
- Coalesce pending notifications so repeated ban/unban actions do not create a backlog of stale messages.
- Deliver pending notifications once when the player joins.

### Restricted-world ejections

- Warn banned players when they are inside a world belonging to their banned hardcore group.
- Forcibly eject them out to the group-spawn after a 30-second grace period. (Currently this grace period is defined by a constant, but could be a new item in config.yml in the future?)
- This is mostly only useful for admin bans, but could also trigger if a group's worlds were changed while the player was offline.
- Preserve the ejection deadline across relogs so reconnecting can't reset the countdown.
- Cancel pending ejections if an admin unbans the player.
- Inform the player when an active ejection countdown has been cancelled.

### Shared group utilities

- Added shared helpers for:
  - checking whether a group contains a world
  - resolving a group's configured respawn location
  - checking ban data and unban times
  - scheduling and cancelling ejections
  - plus a few others

### Respawn and death fixes

- Handle missing or invalid group respawn worlds without passing a null world to `PlayerRespawnEvent`. 
  - Can catch errors made in manual .json edits or if worlds are deleted/renamed
- Log configuration failures and show an in-game warning to affected players.
- Ignore deaths in worlds that are not mapped to a hardcore group.
  - Previously, deaths in an ungrouped world applied a ban that didn't actually have any effect, with `/player list` returning output like this:
> Hardcore banned players (1):
> - SteveHC | Group: (unmapped for world "world") | Unban: 2026-08-11T04:53:19 | Deathworld: world

### Release metadata

- Bumped the Maven/plugin version from `2.1` to `2.2`.

## Validation

Tested in-game with:

- Admin bans while the target is online and inside a hardcore world.
- Admin bans while the target is offline.
- Death-ban followed by leaving the server at the respawn screen.
- Nether portal movement while banned.
- Ban expiry while offline.
- `/player list` before and after expiry.
- Admin unban during an active ejection countdown.
- Relogging during an active ejection countdown.
- Multiple independent players with separate countdown deadlines.
- Two banned players both independently relogging during their separate ejection countdowns.
- Invalid group respawn worlds.
- Player respawn with invalid respawn configuration.
- Deaths in ungrouped worlds.
- General unguided play between myself and another player

Build verification:

`mvn -DskipTests package`

### Potential future changes I'd like upstream dev's input on...

Something I considered but didn't begin implementing is whether the plugin should support an individual player being separately banned from multiple groups at once. Imagine a server has two (or more) groups, arranged something like this:
 
 - Season4SoloHC
   - S4overworldHC
   - S4netherHC
   - S4endHC
 - MultiplayerCoopHC
   - CoopOverwoldHC
   - CoopNetherHC
   - CoopEndHC
 
I was thinking it would be useful to be able to track _multiple bans per player_ for a setup like this. If the admin wanted these groups to function mostly independently, suppose Steve dies in S4endHC and gets banned, he should still be able to go play in CoopNetherHC. But then if Steve dies in _that_ world several hours later, he would be banned independently in _both_ groups. But when his ban expires in group Season4SoloHC, he can rejoin the Season4 group while still banned from the Coop group.

I hope that wasn't too convoluted to follow... And to be honest, I don't _know_ if that's a realistic situation that a server operator would want to set up (_my_ personal server is literally just myself and my daughter and we just have one HC world). But if you think this sounds like a good idea to implement, I'd be happy to start on it. But since it would require changing the underlying data structures in the tracking json files and probably a good deal of the methods that interact with those files, I didn't want to make those kinds of structural changes without consulting with you first. 